### PR TITLE
More efficient historization

### DIFF
--- a/src/SharpTracer.ServiceTest/Program.cs
+++ b/src/SharpTracer.ServiceTest/Program.cs
@@ -42,7 +42,7 @@ namespace SharpTracer.ServiceTest
 
                     var reply = await client.TraceAsync(request);
 
-                    await Task.Delay(new Random().Next(500, 2000));
+                    await Task.Delay(new Random().Next(100, 200));
                 }
             }
             catch (Exception e)
@@ -70,12 +70,12 @@ namespace SharpTracer.ServiceTest
 
                     var reply = await client.HistoryAsync(request);
 
-                    foreach (var item in reply.Requests)
+                    foreach (var item in reply.History)
                     {
                         Console.WriteLine($"{item.ServiceSourceId} -> {item.ServiceDestinationId}");
                     }
 
-                    await Task.Delay(new Random().Next(15000, 20000));
+                    await Task.Delay(new Random().Next(1000, 2000));
                 }
             }
             catch (Exception e)

--- a/src/SharpTracer.ServiceTest/Protos/tracer.proto
+++ b/src/SharpTracer.ServiceTest/Protos/tracer.proto
@@ -32,5 +32,5 @@ message HistoryRequest {
 
 // The History response message containing the history related to the source of interest
 message HistoryResponse {
-	repeated TracerRequest requests = 1;
+	repeated TracerRequest history = 1;
 }

--- a/src/SharpTracer/Protos/tracer.proto
+++ b/src/SharpTracer/Protos/tracer.proto
@@ -12,7 +12,7 @@ service Tracer {
 	rpc History(HistoryRequest) returns (HistoryResponse);
 }
 
-// The request message containing the trace informations.
+// The Tracer request message containing the trace informations.
 message TracerRequest {
 	string serviceSourceId = 1;
 	string serviceDestinationId = 2;
@@ -20,15 +20,17 @@ message TracerRequest {
 	string timestamp = 4;
 }
 
-// The response message containing the trace result.
+// The Tracer response message containing the trace result.
 message TracerResponse {
 	bool result = 1;
 }
 
+// The History request message containing the source of interest
 message HistoryRequest {
 	string sourceId = 1;
 } 
 
+// The History response message containing the history related to the source of interest
 message HistoryResponse {
-	repeated TracerRequest requests = 1;
-} 
+	repeated TracerRequest history = 1;
+}

--- a/src/SharpTracer/Services/HistoryService.cs
+++ b/src/SharpTracer/Services/HistoryService.cs
@@ -1,37 +1,51 @@
 ﻿// (c) 2020 Francesco Del Re <francesco.delre.87@gmail.com>
 // This code is licensed under MIT license (see LICENSE.txt for details)
 using System.Collections.Generic;
-using System.Linq;
 
 namespace SharpTracer.Services
 {
     public interface IHistoryService
     {
-        void SetHistory(List<TracerRequest> history);
+        void SetHistory(string sourceId, List<TracerRequest> history);
         List<TracerRequest> History(string sourceId);
     }
 
     public class HistoryService : IHistoryService
     {
-        private List<TracerRequest> _history;
+        private readonly Dictionary<string, List<TracerRequest>> _historyDictionary;
+
+        public HistoryService()
+        {
+            _historyDictionary = new Dictionary<string, List<TracerRequest>>();
+        }
 
         /// <summary>
         /// Copy the current history.
         /// </summary>
+        /// <param name="sourceId"></param>
         /// <param name="history"></param>
-        public void SetHistory(List<TracerRequest> history)
+        public void SetHistory(string sourceId, List<TracerRequest> history)
         {
-            _history = history?.Select(item => (TracerRequest)item.Clone()).ToList(); ;
+            if (_historyDictionary.TryGetValue(sourceId, out _))
+            {
+                // update the history
+                _historyDictionary[sourceId] = history;
+            }
+            else
+            {
+                // add the history
+                _historyDictionary.Add(sourceId, history);
+            }
         }
 
         /// <summary>
-        /// Return the ordered history of a single node.
+        /// Return the ordered history based on source id.
         /// </summary>
         /// <param name="sourceId"></param>
         /// <returns></returns>
         public List<TracerRequest> History(string sourceId)
         {
-            return _history?.FindAll(x => x.ServiceSourceId == sourceId);
+            return _historyDictionary[sourceId];
         }
     }
 }

--- a/src/SharpTracer/Services/TracerService.cs
+++ b/src/SharpTracer/Services/TracerService.cs
@@ -20,7 +20,7 @@ namespace SharpTracer.Services
         }
 
         /// <summary>
-        /// Insert a new Trace.
+        /// Insert a new trace.
         /// </summary>
         /// <param name="request"></param>
         /// <param name="context"></param>
@@ -49,7 +49,7 @@ namespace SharpTracer.Services
 
             return Task.FromResult(new HistoryResponse
             {
-                Requests = { _historyService.History(request.SourceId) }
+                History = { _historyService.History(request.SourceId) }
             });
         }
     }


### PR DESCRIPTION
The data structure for the historicization and ordering of requests has been modified, passing from a list to a dictionary.
In this way, the sort only affects the history of the current node and the get will be in O(1).

This is the pull request for the issue #1 